### PR TITLE
Poprawione odsyłacze do FB

### DIFF
--- a/_includes/choir.html
+++ b/_includes/choir.html
@@ -9,7 +9,7 @@
                                  data-hide-cover="false"
                                  data-show-facepile="false">
                 <blockquote cite="{{ include.fb_link }}" class="fb-xfbml-parse-ignore">
-                    <a href="{{ include.fb_link }}">{{ include.fb_name }}</a>
+                    <a href="{{ include.fb_link }}">Profil na Facebooku</a>
                 </blockquote>
             </div>
         </div>

--- a/_includes/choir.html
+++ b/_includes/choir.html
@@ -9,7 +9,7 @@
                                  data-hide-cover="false"
                                  data-show-facepile="false">
                 <blockquote cite="{{ include.fb_link }}" class="fb-xfbml-parse-ignore">
-                    <a href="{{ include.fb_link }}">Chór MIM UW</a>
+                    <a href="{{ include.fb_link }}">{{ include.fb_name }}</a>
                 </blockquote>
             </div>
         </div>

--- a/about.md
+++ b/about.md
@@ -25,7 +25,6 @@ Szeliga**.
 
 {% include choir.html
     fb_link="https://www.facebook.com/ChorWBUW/"
-    fb_name="Chór Wydziału Biologii"
     description=biologia
 %}
 
@@ -42,7 +41,6 @@ na SGH, specjalistka ds. promocji w wydawnictwie Świat Książki.
 
 {% include choir.html
     fb_link="https://www.facebook.com/Chór-Wydziału-Fizyki-UW-157158194306674/"
-    fb_name="Chór Wydziału Fizyki UW"
     description=fizyka
     web_page="http://chor.fuw.edu.pl"
 %}
@@ -60,7 +58,6 @@ chóralnej na UMFC.
 
 {% include choir.html
     fb_link="https://www.facebook.com/ChorMIM/"
-    fb_name="Chór MIM UW"
     description=mim
     web_page="http://chor.mimuw.edu.pl"
 %}
@@ -77,6 +74,5 @@ Współpracuje z Chórem Akademickim UW jako instruktorka głosowa.
 
 {% include choir.html
     fb_link="https://facebook.com/chorWZUW/"
-    fb_name="Chór Wydziału Zarządzania UW"
     description=zarzadzanie
 %}

--- a/about.md
+++ b/about.md
@@ -25,6 +25,7 @@ Szeliga**.
 
 {% include choir.html
     fb_link="https://www.facebook.com/ChorWBUW/"
+    fb_name="Chór Wydziału Biologii"
     description=biologia
 %}
 
@@ -41,6 +42,7 @@ na SGH, specjalistka ds. promocji w wydawnictwie Świat Książki.
 
 {% include choir.html
     fb_link="https://www.facebook.com/Chór-Wydziału-Fizyki-UW-157158194306674/"
+    fb_name="Chór Wydziału Fizyki UW"
     description=fizyka
     web_page="http://chor.fuw.edu.pl"
 %}
@@ -58,6 +60,7 @@ chóralnej na UMFC.
 
 {% include choir.html
     fb_link="https://www.facebook.com/ChorMIM/"
+    fb_name="Chór MIM UW"
     description=mim
     web_page="http://chor.mimuw.edu.pl"
 %}
@@ -74,5 +77,6 @@ Współpracuje z Chórem Akademickim UW jako instruktorka głosowa.
 
 {% include choir.html
     fb_link="https://facebook.com/chorWZUW/"
+    fb_name="Chór Wydziału Zarządzania UW"
     description=zarzadzanie
 %}


### PR DESCRIPTION
Zgaduję, że tam miało być coś w ogóle innego np. widżet Fejsa, ale jak się nie wczytuje, to zostaje w tym miejscu napis "Chór MIM UW"

Testowałem niestety tylko lokalnie na dużo nowszym Jekyllu

Jeśli ożywiam i roztrząsam archiwalne repo wrzucone tylko dla jawności, to przepraszam